### PR TITLE
Bump `pyproject.toml` for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ndbc-api"
-version = "0.24.08.04.1"
+version = "0.24.08.28.1"
 description = "A Python API for the National Data Buoy Center."
 authors = ["cdjellen <cdjellen@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary of core changes:
* No major changes, simply bumping `pyproject.toml` version from PR #41 

## Future changes:
* Please see the list in #41 
