### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.13"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ The `ndbc-api` can be installed via PIP:
 pip install ndbc-api
 ```
 
+Conda users can install the `ndbc-api` via the `conda-forge` channel:
+
+```sh
+conda install -c conda-forge ndbc-api
+```
+
+Finally, to install the `ndbc-api` from source, clone the repository and run the following command:
+
+```sh
+python setup.py install
+```
+
 #### Requirements
 The `ndbc-api` has been tested on Python 3.6, 3.7, 3.8, 3.9, and 3.10. Python 2 support is not currently planned, but could be implemented based on the needs of the atmospheric research community.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ndbc-api"
-version = "0.24.11.17.1"
+version = "0.24.11.19.1"
 description = "A Python API for the National Data Buoy Center."
 authors = ["cdjellen <cdjellen@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.13"
+python = ">=3.8,<3.14"
 requests = ">=2.10.0"
 pandas = ">=1.5.3"
 numpy  = ">=1.24.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.14"
+python = ">=3.8,<3.13"
 requests = ">=2.10.0"
 pandas = ">=1.5.3"
 numpy  = ">=1.24.3"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 setuptools.setup(
     name='ndbc-api',
     packages=setuptools.find_packages(exclude=['*tests*']),
-    version='0.24.06.12.1',
+    version='0.24.11.19.1',
     license='MIT',
     description='A Python API for the National Data Buoy Center.',
     author='Chris Jellen',
@@ -16,15 +16,16 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     download_url='https://github.com/cdjellen/ndbc-api/tarball/main',
     keywords=['ndbc', 'python3', 'api', 'oceanography', 'buoy', 'atmospheric'],
-    install_requires=['requests', 'pandas', 'bs4', 'html5lib'],
+    install_requires=['requests', 'pandas', 'bs4', 'html5lib', 'scipy', 'xarray'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
### Summary of core changes:
* Include conda installation instructions
* Include instructions for local build from source
* Include support for Python 3.13
* Update CI for Python 3.13

### Future improvements:
* Include station metadata with `xarray.Dataset` responses when `get_data` is called for a single station
* Update flags in accordance with migration from `netCDF4` to `xarray`